### PR TITLE
add medibloc

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ Note: Please do not use 266 as port prefix because this is the default
 | ....                |             |
 | Initia Yominet      | 400         |
 | Initia Civitia      | 401         |
-| Mediblock           | 403         |
+| Medibloc            | 403         |
 
 ## JSON API
 

--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ Note: Please do not use 266 as port prefix because this is the default
 | ....                |             |
 | Initia Yominet      | 400         |
 | Initia Civitia      | 401         |
+| Mediblock           | 403         |
 
 ## JSON API
 

--- a/networks.json
+++ b/networks.json
@@ -201,5 +201,6 @@
   "lumera": 307,
   "sphx": 308,
   "initia_yominet": 400,
-  "initia_civitia": 401
+  "initia_civitia": 401,
+  "medibloc": 403
 }


### PR DESCRIPTION
Description:

- Adding `Port` for [Medibloc](https://medibloc.com/)

Details:

- Medibloc Official [GitHub](https://github.com/medibloc) page
- Medibloc chain parameters
```
  {
    "name": "medibloc",
    "githubUrl": "medibloc/panacea-core",
    "daemonName": "panacead",
    "chainId": "panacea-3",
    "binaryVersion": "v2.2.0-1",
    "goVersion": "go1.22",
    "networkType": "mainnet",
  }
```
- [Snapshot support details](https://www.imperator.co/services/chain-services/mainnets/medibloc)